### PR TITLE
:LoadCharacter Edge-case/Hotfix

### DIFF
--- a/CameraService.lua
+++ b/CameraService.lua
@@ -295,7 +295,13 @@ local function updateCamera(deltaTime)
 	if self.Zoom > 0 and self.Smoothness > 0 then
 		local function damper()
 			local hum = currentCharacter:FindFirstChild("Humanoid")
-			if hum and hum:GetState() == Enum.HumanoidStateType.Jumping or hum:GetState() == Enum.HumanoidStateType.Freefall then
+			local humState
+		
+			if hum then
+				humState = hum:GetState()
+			end
+		
+			if (humState == Enum.HumanoidStateType.Jumping) or (humState == Enum.HumanoidStateType.Freefall) then
 				lapsed = 0
 				return desiredTime * 3.33
 			end
@@ -305,7 +311,7 @@ local function updateCamera(deltaTime)
 			else		
 				return math.max(desiredTime, desiredTime * (3.33 - (lapsed - (1 / deltaTime)) * .03))
 			end
-
+		
 		end
 		desired2 = damper()
 	end


### PR DESCRIPTION
There is an issue when Player:LoadCharacter() is called from the server, leading to error spam in output.  This pull request fixes the issue, which is rooted in the conditional check which assumes Humanoid existence.

Note: line number do not match up with source in attachments, due to some modifications for a specific-use case.  Pull request does match original source, however.

https://github.com/LugicalDev/CameraService/assets/54006975/a71a7296-d031-477f-87df-f9f0d23dab31

![Issue Identified in Codebase](https://github.com/LugicalDev/CameraService/assets/54006975/792f1985-71fe-4c85-94ed-3cc45a4a1542)

https://github.com/LugicalDev/CameraService/assets/54006975/e92d033e-a248-40f1-9d7d-c3aca96264ef

